### PR TITLE
Only hide non empty sensitive payloads

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.5.1
+
+- Hide only valid (non-empty) payload values sent to salt CLI
+
 # 0.5.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/actions/lib/utils.py
+++ b/actions/lib/utils.py
@@ -1,5 +1,6 @@
 # pylint: disable=line-too-long
 
+import six
 import yaml
 from .meta import actions
 
@@ -64,6 +65,19 @@ def sanitize_payload(keys_to_sanitize, payload):
     publishing to the logs
     '''
     data = payload.copy()
-    keys_to_sanitize = [k for k in keys_to_sanitize if payload.get(k, None)]
-    map(lambda k: data.update({k: "*" * len(payload[k])}), keys_to_sanitize)
+
+    def to_stars(val):
+        if isinstance(val, six.string_types):
+            return '*' * len(val)
+        else:
+            return '*'
+
+    for k in keys_to_sanitize:
+        val = payload.get(k, None)
+        if not val:
+            continue
+        else:
+            val = to_stars(val)
+
+        data[k] = val
     return data

--- a/actions/lib/utils.py
+++ b/actions/lib/utils.py
@@ -64,5 +64,6 @@ def sanitize_payload(keys_to_sanitize, payload):
     publishing to the logs
     '''
     data = payload.copy()
+    keys_to_sanitize = [k for k in keys_to_sanitize if payload.get(k, None)]
     map(lambda k: data.update({k: "*" * len(payload[k])}), keys_to_sanitize)
     return data

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - salt
   - cfg management
   - configuration management
-version : 0.5.0
+version : 0.5.1
 author : jcockhren
 email : jurnell@sophicware.com


### PR DESCRIPTION
closes: https://github.com/StackStorm-Exchange/stackstorm-salt/issues/2

Before:

```
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯ st2 run salt.local module=test.ping                                   ⏎ results_tracker_perf ✭ ✱ ◼
..
id: 5923366ed9d7ed3460ed6aab
status: failed
parameters:
  module: test.ping
result:
  exit_code: 1
  result: None
  stderr: "Traceback (most recent call last):
  File "/mnt/src/storm/st2/st2common/st2common/runners/python_action_wrapper.py", line 259, in <module>
    obj.run()
  File "/mnt/src/storm/st2/st2common/st2common/runners/python_action_wrapper.py", line 155, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/salt/actions/local.py", line 35, in run
    data=kwargs)
  File "/opt/stackstorm/packs/salt/actions/lib/base.py", line 62, in generate_package
    clean_payload = sanitize_payload(('username', 'password'), self.data)
  File "/opt/stackstorm/packs/salt/actions/lib/utils.py", line 67, in sanitize_payload
    map(lambda k: data.update({k: "*" * len(payload[k])}), keys_to_sanitize)
  File "/opt/stackstorm/packs/salt/actions/lib/utils.py", line 67, in <lambda>
    map(lambda k: data.update({k: "*" * len(payload[k])}), keys_to_sanitize)
TypeError: object of type 'NoneType' has no len()
"
  stdout: ''
```

After:

```
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯ st2 run salt.local module=test.ping                                     results_tracker_perf ✭ ✱ ◼
.
id: 59233bfad9d7ed4bbc4e605d
status: failed
parameters:
  module: test.ping
result:
  exit_code: 1
  result: None
  stderr: "st2.actions.python.SaltLocal: INFO     [salt] Payload to be sent: {'username': '*', 'expr_form': u'glob', 'eauth': None, 'tgt': u'*', 'fun': u'test.ping', 'password': '*', 'client': 'local'}
st2.actions.python.SaltLocal: INFO     [salt] Request generated
st2.actions.python.SaltLocal: INFO     [salt] Preparing to send
Traceback (most recent call last):
  File "/mnt/src/storm/st2/st2common/st2common/runners/python_action_wrapper.py", line 259, in <module>
    obj.run()
  File "/mnt/src/storm/st2/st2common/st2common/runners/python_action_wrapper.py", line 155, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/salt/actions/local.py", line 40, in run
    resp = Session().send(request, verify=self.verify_ssl)
  File "/mnt/src/storm/st2/virtualenv/lib/python2.7/site-packages/requests/sessions.py", line 639, in send
    r = adapter.send(request, **kwargs)
  File "/mnt/src/storm/st2/virtualenv/lib/python2.7/site-packages/requests/adapters.py", line 502, in send
    raise ConnectionError(e, request=request)
requests.exceptions.ConnectionError: HTTPSConnectionPool(host='salt.example.com', port=443): Max retries exceeded with url: /run (Caused by NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x7fc418058b10>: Failed to establish a new connection: [Errno -2] Name or service not known',))
"
  stdout: ''
```