### PR TITLE
Set args=None for test.ping and test.version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change Log
 
+# 0.7.0
+
+- Set `args=None` for `test.ping` and `test.version`
+- This is so action works with ChatOps and newer ST2 versions that will
+  provide default value even for non-required parameters.
+
 # 0.6.0
 
 - Updated action `runner_type` from `run-python` to `python-script`

--- a/actions/local.py
+++ b/actions/local.py
@@ -27,12 +27,25 @@ class SaltLocal(SaltAction):
             st2 run salt.local module=test.ping matches='web*'
             st2 run salt.local module=test.ping expr_form=grain target='os:Ubuntu'
         '''
-        self.generate_package('local',
-                              cmd=module,
-                              target=target,
-                              expr_form=expr_form,
-                              args=args,
-                              data=kwargs)
+
+        # ChatOps alias and newer ST2 versions set default args=[]
+        # This breaks test.ping & test.version
+
+        if module not in ['test.ping', 'test.version']:
+            self.generate_package('local',
+                                  cmd=module,
+                                  target=target,
+                                  expr_form=expr_form,
+                                  args=args,
+                                  data=kwargs)
+        else:
+            self.generate_package('local',
+                                  cmd=module,
+                                  target=target,
+                                  expr_form=expr_form,
+                                  args=None,
+                                  data=kwargs)
+
         request = self.generate_request()
         self.logger.info('[salt] Request generated')
         request.prepare_body(json.dumps(self.data), None)

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - salt
   - cfg management
   - configuration management
-version : 0.6.0
+version : 0.7.0
 author : jcockhren
 email : jurnell@sophicware.com


### PR DESCRIPTION
The `salt-local` alias sets `args=[]` by default. This causes problems for `test.ping` and `test.version` when called from ChatOps, as they expect no args values. 

This will also cause problems for newer ST2 versions, which pass default values for non-required parameters.

Fixes https://github.com/StackStorm/st2contrib/issues/517