### PR TITLE
Don't send `args=None` for client actions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,19 +1,23 @@
 # Change Log
 
-# 0.7.0
+## 0.7.2
+
+- Do not send `args=None` for client actions. This was breaking on modules like `test.ping`.
+
+## 0.7.0
 
 - Set `args=None` for `test.ping` and `test.version`
 - This is so action works with ChatOps and newer ST2 versions that will
   provide default value even for non-required parameters.
 
-# 0.6.0
+## 0.6.0
 
 - Updated action `runner_type` from `run-python` to `python-script`
 
-# 0.5.1
+## 0.5.1
 
 - Hide only valid (non-empty) payload values sent to salt CLI
 
-# 0.5.0
+## 0.5.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/actions/client.py
+++ b/actions/client.py
@@ -13,5 +13,8 @@ class SaltClientAction(Action):
                     kwargs='{"pkgs":["git","httpd"]}'
         '''
         cli = salt.client.LocalClient()
-        ret = cli.cmd(matches, module, arg=args, kwarg=kwargs)
+        if args is None:
+            ret = cli.cmd(matches, module, kwarg=kwargs)
+        else:
+            ret = cli.cmd(matches, module, arg=args, kwarg=kwargs)
         return ret

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,11 +1,11 @@
 ---
 ref: salt
 name : salt
-description : st2 salt integration pack
+description : salt integration pack
 keywords:
   - salt
   - cfg management
   - configuration management
-version: 0.7.1
+version: 0.7.2
 author : jcockhren
 email : jurnell@sophicware.com


### PR DESCRIPTION
 Some modules do not require any args, e.g. `test.ping`. 

If you are using this with `salt.client`, it will fail, as ST2 sets `args` to `None` if nothing is specified, rather than an empty list. This change will not attempt to send any args if args=None. If it is anything else, it will be handled as before.

Fixes https://github.com/StackStorm/st2/issues/3906