### PR TITLE
Changing expr_form to tgt_type for Salt 2019.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.8.0
+
+- Changed expr_form to tgt_type as SaltStack upstream has replaced the functionality.
+
 ## 0.7.2
 
 - Do not send `args=None` for client actions. This was breaking on modules like `test.ping`.

--- a/actions/lib/base.py
+++ b/actions/lib/base.py
@@ -51,7 +51,7 @@ class SaltAction(Action):
         self.data['password'] = self.password
         if cmd:
             self.data['fun'] = cmd
-        if client is 'local':
+        if client == 'local':
             self.data['tgt'] = kwargs.get('target', '*')
             self.data['tgt_type'] = kwargs.get('tgt_type', 'glob')
         if isinstance(kwargs.get('args', []), list) and len(kwargs.get('args', [])) > 0:

--- a/actions/lib/base.py
+++ b/actions/lib/base.py
@@ -53,7 +53,7 @@ class SaltAction(Action):
             self.data['fun'] = cmd
         if client is 'local':
             self.data['tgt'] = kwargs.get('target', '*')
-            self.data['expr_form'] = kwargs.get('expr_form', 'glob')
+            self.data['tgt_type'] = kwargs.get('tgt_type', 'glob')
         if isinstance(kwargs.get('args', []), list) and len(kwargs.get('args', [])) > 0:
             self.data['arg'] = kwargs['args']
         if len(kwargs.get('data', {})) > 0:

--- a/actions/local.py
+++ b/actions/local.py
@@ -19,13 +19,13 @@ class SaltLocal(SaltAction):
         'status'
     ]
 
-    def run(self, module, target, expr_form, args, **kwargs):
+    def run(self, module, target, tgt_type, args, **kwargs):
         self.verify_ssl = self.config.get('verify_ssl', True)
         '''
         CLI Examples:
 
             st2 run salt.local module=test.ping matches='web*'
-            st2 run salt.local module=test.ping expr_form=grain target='os:Ubuntu'
+            st2 run salt.local module=test.ping tgt_type=grain target='os:Ubuntu'
         '''
 
         # ChatOps alias and newer ST2 versions set default args=[]
@@ -35,14 +35,14 @@ class SaltLocal(SaltAction):
             self.generate_package('local',
                                   cmd=module,
                                   target=target,
-                                  expr_form=expr_form,
+                                  tgt_type=tgt_type,
                                   args=args,
                                   data=kwargs)
         else:
             self.generate_package('local',
                                   cmd=module,
                                   target=target,
-                                  expr_form=expr_form,
+                                  tgt_type=tgt_type,
                                   args=None,
                                   data=kwargs)
 

--- a/actions/local.yaml
+++ b/actions/local.yaml
@@ -14,7 +14,7 @@ parameters:
         type: 'string'
         required: false
         default: '*'
-    expr_form:
+    tgt_type:
         description: 'Criteria used for matching minions'
         type: 'string'
         required: false

--- a/actions/local_archive.gunzip.yaml
+++ b/actions/local_archive.gunzip.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_archive.gzip.yaml
+++ b/actions/local_archive.gzip.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_archive.rar.yaml
+++ b/actions/local_archive.rar.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_archive.tar.yaml
+++ b/actions/local_archive.tar.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_archive.unrar.yaml
+++ b/actions/local_archive.unrar.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_archive.unzip.yaml
+++ b/actions/local_archive.unzip.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_archive.zip_.yaml
+++ b/actions/local_archive.zip_.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cloud.action.yaml
+++ b/actions/local_cloud.action.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cloud.create.yaml
+++ b/actions/local_cloud.create.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cloud.destroy.yaml
+++ b/actions/local_cloud.destroy.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cloud.network_create.yaml
+++ b/actions/local_cloud.network_create.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cloud.profile_.yaml
+++ b/actions/local_cloud.profile_.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cloud.virtual_interface_create.yaml
+++ b/actions/local_cloud.virtual_interface_create.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cloud.volume_attach.yaml
+++ b/actions/local_cloud.volume_attach.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cloud.volume_create.yaml
+++ b/actions/local_cloud.volume_create.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cloud.volume_delete.yaml
+++ b/actions/local_cloud.volume_delete.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cloud.volume_detach.yaml
+++ b/actions/local_cloud.volume_detach.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cmdmod.run.yaml
+++ b/actions/local_cmdmod.run.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cmdmod.run_chroot.yaml
+++ b/actions/local_cmdmod.run_chroot.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cmdmod.script.yaml
+++ b/actions/local_cmdmod.script.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cp.get_file.yaml
+++ b/actions/local_cp.get_file.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cp.get_url.yaml
+++ b/actions/local_cp.get_url.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cp.push.yaml
+++ b/actions/local_cp.push.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cp.push_dir.yaml
+++ b/actions/local_cp.push_dir.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cron.ls.yaml
+++ b/actions/local_cron.ls.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cron.rm_env.yaml
+++ b/actions/local_cron.rm_env.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cron.rm_job.yaml
+++ b/actions/local_cron.rm_job.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cron.set_env.yaml
+++ b/actions/local_cron.set_env.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_cron.set_job.yaml
+++ b/actions/local_cron.set_job.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_data.cas.yaml
+++ b/actions/local_data.cas.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_data.dump.yaml
+++ b/actions/local_data.dump.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_data.getval.yaml
+++ b/actions/local_data.getval.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_data.update.yaml
+++ b/actions/local_data.update.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_event.fire.yaml
+++ b/actions/local_event.fire.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_event.fire_master.yaml
+++ b/actions/local_event.fire_master.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_event.send.yaml
+++ b/actions/local_event.send.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_file.access.yaml
+++ b/actions/local_file.access.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_file.chgrp.yaml
+++ b/actions/local_file.chgrp.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_file.chown.yaml
+++ b/actions/local_file.chown.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_file.directory_exists.yaml
+++ b/actions/local_file.directory_exists.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_file.file_exists.yaml
+++ b/actions/local_file.file_exists.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_file.find.yaml
+++ b/actions/local_file.find.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_file.manage_file.yaml
+++ b/actions/local_file.manage_file.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_file.mkdir.yaml
+++ b/actions/local_file.mkdir.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_file.remove.yaml
+++ b/actions/local_file.remove.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_file.replace.yaml
+++ b/actions/local_file.replace.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_file.search.yaml
+++ b/actions/local_file.search.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_file.symlink.yaml
+++ b/actions/local_file.symlink.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_file.touch.yaml
+++ b/actions/local_file.touch.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_file.truncate.yaml
+++ b/actions/local_file.truncate.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_grains.append.yaml
+++ b/actions/local_grains.append.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_grains.delval.yaml
+++ b/actions/local_grains.delval.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_grains.get.yaml
+++ b/actions/local_grains.get.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_grains.remove.yaml
+++ b/actions/local_grains.remove.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_grains.setval.yaml
+++ b/actions/local_grains.setval.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_hosts.add_hosts.yaml
+++ b/actions/local_hosts.add_hosts.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_hosts.get_alias.yaml
+++ b/actions/local_hosts.get_alias.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_hosts.get_ip.yaml
+++ b/actions/local_hosts.get_ip.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_hosts.rm_host.yaml
+++ b/actions/local_hosts.rm_host.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_hosts.set_host.yaml
+++ b/actions/local_hosts.set_host.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_htpasswd.useradd.yaml
+++ b/actions/local_htpasswd.useradd.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_htpasswd.userdel.yaml
+++ b/actions/local_htpasswd.userdel.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_mine.delete.yaml
+++ b/actions/local_mine.delete.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_mine.get.yaml
+++ b/actions/local_mine.get.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_mine.send.yaml
+++ b/actions/local_mine.send.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_mine.update.yaml
+++ b/actions/local_mine.update.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_network.connect.yaml
+++ b/actions/local_network.connect.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_network.interface_ip.yaml
+++ b/actions/local_network.interface_ip.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_network.ipaddrs.yaml
+++ b/actions/local_network.ipaddrs.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_network.ping.yaml
+++ b/actions/local_network.ping.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_network.subnets.yaml
+++ b/actions/local_network.subnets.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_pillar.get.yaml
+++ b/actions/local_pillar.get.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_pip.freeze.yaml
+++ b/actions/local_pip.freeze.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_pip.install.yaml
+++ b/actions/local_pip.install.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_pip.uninstall.yaml
+++ b/actions/local_pip.uninstall.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_pkg.install.yaml
+++ b/actions/local_pkg.install.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_pkg.refresh_db.yaml
+++ b/actions/local_pkg.refresh_db.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_pkg.remove.yaml
+++ b/actions/local_pkg.remove.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_puppet.disable.yaml
+++ b/actions/local_puppet.disable.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_puppet.enable.yaml
+++ b/actions/local_puppet.enable.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_puppet.fact.yaml
+++ b/actions/local_puppet.fact.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_puppet.noop.yaml
+++ b/actions/local_puppet.noop.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_puppet.run.yaml
+++ b/actions/local_puppet.run.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_puppet.status.yaml
+++ b/actions/local_puppet.status.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_puppet.summary.yaml
+++ b/actions/local_puppet.summary.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_ret.get_fun.yaml
+++ b/actions/local_ret.get_fun.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_ret.get_jid.yaml
+++ b/actions/local_ret.get_jid.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_ret.get_jids.yaml
+++ b/actions/local_ret.get_jids.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_ret.get_minions.yaml
+++ b/actions/local_ret.get_minions.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_saltutil.sync_all.yaml
+++ b/actions/local_saltutil.sync_all.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_saltutil.sync_grains.yaml
+++ b/actions/local_saltutil.sync_grains.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_saltutil.sync_modules.yaml
+++ b/actions/local_saltutil.sync_modules.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_saltutil.sync_outputters.yaml
+++ b/actions/local_saltutil.sync_outputters.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_saltutil.sync_renderers.yaml
+++ b/actions/local_saltutil.sync_renderers.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_saltutil.sync_returners.yaml
+++ b/actions/local_saltutil.sync_returners.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_saltutil.sync_states.yaml
+++ b/actions/local_saltutil.sync_states.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_saltutil.sync_utils.yaml
+++ b/actions/local_saltutil.sync_utils.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_schedule.add.yaml
+++ b/actions/local_schedule.add.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_schedule.delete.yaml
+++ b/actions/local_schedule.delete.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_schedule.disable_job.yaml
+++ b/actions/local_schedule.disable_job.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_schedule.enable_job.yaml
+++ b/actions/local_schedule.enable_job.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_schedule.run_job.yaml
+++ b/actions/local_schedule.run_job.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_service.available.yaml
+++ b/actions/local_service.available.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_service.restart.yaml
+++ b/actions/local_service.restart.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_service.start.yaml
+++ b/actions/local_service.start.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_service.status.yaml
+++ b/actions/local_service.status.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_service.stop.yaml
+++ b/actions/local_service.stop.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_shadow.del_password.yaml
+++ b/actions/local_shadow.del_password.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_shadow.gen_password.yaml
+++ b/actions/local_shadow.gen_password.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_shadow.set_expire.yaml
+++ b/actions/local_shadow.set_expire.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_state.highstate.yaml
+++ b/actions/local_state.highstate.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_state.single.yaml
+++ b/actions/local_state.single.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_state.sls.yaml
+++ b/actions/local_state.sls.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_supervisord.add.yaml
+++ b/actions/local_supervisord.add.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_supervisord.custom.yaml
+++ b/actions/local_supervisord.custom.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_supervisord.remove.yaml
+++ b/actions/local_supervisord.remove.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_supervisord.reread.yaml
+++ b/actions/local_supervisord.reread.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_supervisord.restart.yaml
+++ b/actions/local_supervisord.restart.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_supervisord.start.yaml
+++ b/actions/local_supervisord.start.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_supervisord.stop.yaml
+++ b/actions/local_supervisord.stop.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_systemd.available.yaml
+++ b/actions/local_systemd.available.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_systemd.disable.yaml
+++ b/actions/local_systemd.disable.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_systemd.enable.yaml
+++ b/actions/local_systemd.enable.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_systemd.restart.yaml
+++ b/actions/local_systemd.restart.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_systemd.start.yaml
+++ b/actions/local_systemd.start.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_systemd.stop.yaml
+++ b/actions/local_systemd.stop.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_systemd.systemctl_reload.yaml
+++ b/actions/local_systemd.systemctl_reload.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_test.cross_test.yaml
+++ b/actions/local_test.cross_test.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_test.echo.yaml
+++ b/actions/local_test.echo.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_test.ping.yaml
+++ b/actions/local_test.ping.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_useradd.add.yaml
+++ b/actions/local_useradd.add.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_useradd.chshell.yaml
+++ b/actions/local_useradd.chshell.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/actions/local_useradd.delete.yaml
+++ b/actions/local_useradd.delete.yaml
@@ -12,7 +12,7 @@ parameters:
      required: false
      type: string
      default: '*'
-  expr_form:
+  tgt_type:
     required: false
     type: string
     default: glob

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - salt
   - cfg management
   - configuration management
-version: 0.7.2
+version: 0.8.0
 author : jcockhren
 email : jurnell@sophicware.com

--- a/tests/test_action_local.py
+++ b/tests/test_action_local.py
@@ -12,21 +12,21 @@ __all__ = [
 no_args = {
     'module': 'this.something',
     'target': '*',
-    'expr_form': 'glob',
+    'tgt_type': 'glob',
     'args': []
 }
 
 one_arg = {
     'module': 'this.something',
     'target': '*',
-    'expr_form': 'glob',
+    'tgt_type': 'glob',
     'args': ['os'],
 }
 
 multiple_args = {
     'module': 'this.something',
     'target': '*',
-    'expr_form': 'glob',
+    'tgt_type': 'glob',
     'args': ['this', 'that', 'home'],
 }
 


### PR DESCRIPTION
This PR is to change expr_form to tgt_type to ensure the salt pack will continue to work against the salt API. In 2019.2, expr_form was completely dropped, thus, different forms such as 'list' could not be specified.