### PR TITLE
Support Python 2 and 3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.8.4
+
+- Pin salt < 3001 and jinja2 < 2.11.1 to support both Python 2 and 3
+
 ## 0.8.3
 
 - Add explicit support for Python 2 and 3

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - salt
   - cfg management
   - configuration management
-version: 0.8.3
+version: 0.8.4
 author : jcockhren
 email : jurnell@sophicware.com
 python_versions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-salt
+jinja2<2.11.1  # transitive dependency via salt, last version to support Python 2.7 and 3+
+salt<3001  # last version to support Python 2.7 and 3+
 salt-pepper
 requests


### PR DESCRIPTION
Pin the `salt` and `Jinja2` dependencies so it still supports Python 2.