### PR TITLE
Add HTTP response to logger to help debug failed requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.1
+
+* Add logging of HTTP Code response from Salt API
+
 ## 1.0.0
 
 * Drop Python 2.7 support

--- a/actions/local.py
+++ b/actions/local.py
@@ -51,4 +51,5 @@ class SaltLocal(SaltAction):
         request.prepare_body(json.dumps(self.data), None)
         self.logger.info('[salt] Preparing to send')
         resp = Session().send(request, verify=self.verify_ssl)
+        self.logger.debug('[salt] Response http code: %s', resp.status_code)
         return resp.json()

--- a/actions/runner.py
+++ b/actions/runner.py
@@ -27,6 +27,9 @@ class SaltRunner(SaltAction):
         if kwargs.get('kwargs', None) is not None:
             self.data.update(kwargs['kwargs'])
         request = self.generate_request()
+        self.logger.info('[salt] Request generated')
         request.prepare_body(json.dumps(self.data), None)
+        self.logger.info('[salt] Preparing to send')
         resp = Session().send(request, verify=self.verify_ssl)
+        self.logger.debug('[salt] Response http code: %s', resp.status_code)
         return resp.json()

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - salt
   - cfg management
   - configuration management
-version: 1.0.0
+version: 1.0.1
 author : jcockhren
 email : jurnell@sophicware.com
 python_versions:


### PR DESCRIPTION
Salt API does not return JSON for unauthorized access. 
Adding the HTTP Status Code to the logger at the debug level.
This allows for an improved debugging experience