### PR TITLE
upgrade salt to latest. pack was not installing on fresh stackstorm install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-jinja2<2.11.1  # transitive dependency via salt, last version to support Python 2.7 and 3+
-salt<3001  # last version to support Python 2.7 and 3+
+salt
 salt-pepper
 requests


### PR DESCRIPTION
I was unable to install the the salt pack on latest (docker-compose setup) of stackstorm. 
Before:
```

{
  "output": {
    "packs_list": [
      "salt"
    ],
    "message": "",
    "conflict_list": [],
    "warning_list": null
  },
  "errors": [
    {
      "type": "error",
      "message": "Execution failed. See result for details.",
      "task_id": "install_pack_requirements",
      "result": {
        "stdout": "",
        "stderr": "st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Setting up virtualenv for pack \"salt\" (/opt/stackstorm/packs/salt)\nst2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Removing virtualenv in \"/opt/stackstorm/virtualenvs/salt\"\nst2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Virtualenv successfully removed.\nst2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Creating virtualenv for pack \"salt\" in \"/opt/stackstorm/virtualenvs/salt\"\nst2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Creating virtualenv in \"/opt/stackstorm/virtualenvs/salt\" using Python binary \"/opt/stackstorm/st2/bin/python\"\nst2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Running command \"/opt/stackstorm/st2/bin/virtualenv -p /opt/stackstorm/st2/bin/python --always-copy --verbose --no-download /opt/stackstorm/virtualenvs/salt\" to create virtualenv.\nst2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Installing base requirements\nst2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Installing requirement six>=1.9.0,<2.0 with command /opt/stackstorm/virtualenvs/salt/bin/pip install six>=1.9.0,<2.0.\nst2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Installing pack specific requirements from \"/opt/stackstorm/packs/salt/requirements.txt\"\nst2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Installing requirements from file /opt/stackstorm/packs/salt/requirements.txt with command /opt/stackstorm/virtualenvs/salt/bin/pip install -U -r /opt/stackstorm/packs/salt/requirements.txt.\nTraceback (most recent call last):\n  File \"/opt/stackstorm/st2/lib/python3.8/site-packages/python_runner/python_action_wrapper.py\", line 395, in <module>\n    obj.run()\n  File \"/opt/stackstorm/st2/lib/python3.8/site-packages/python_runner/python_action_wrapper.py\", line 214, in run\n    output = action.run(**self._parameters)\n  File \"/opt/stackstorm/packs/packs/actions/pack_mgmt/setup_virtualenv.py\", line 93, in run\n    setup_pack_virtualenv(\n  File \"/opt/stackstorm/st2/lib/python3.8/site-packages/st2common/util/virtualenvs.py\", line 133, in setup_pack_virtualenv\n    install_requirements(\n  File \"/opt/stackstorm/st2/lib/python3.8/site-packages/st2common/util/virtualenvs.py\", line 301, in install_requirements\n    raise Exception(\nException: Failed to install requirements from \"/opt/stackstorm/packs/salt/requirements.txt\": Collecting jinja2<2.11.1\n  Using cached Jinja2-2.11.0-py2.py3-none-any.whl (126 kB)\nCollecting salt<3001\n  Using cached salt-3000.9.tar.gz (15.3 MB)\n (stderr:     ERROR: Command errored out with exit status 1:\n     command: /opt/stackstorm/virtualenvs/salt/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '\"'\"'/tmp/pip-install-9aj1_89m/salt_c268f994786e4625b26e772ffcf34b8f/setup.py'\"'\"'; __file__='\"'\"'/tmp/pip-install-9aj1_89m/salt_c268f994786e4625b26e772ffcf34b8f/setup.py'\"'\"';f=getattr(tokenize, '\"'\"'open'\"'\"', open)(__file__);code=f.read().replace('\"'\"'\\r\\n'\"'\"', '\"'\"'\\n'\"'\"');f.close();exec(compile(code, __file__, '\"'\"'exec'\"'\"'))' egg_info --egg-base /tmp/pip-pip-egg-info-3fy883h4\n         cwd: /tmp/pip-install-9aj1_89m/salt_c268f994786e4625b26e772ffcf34b8f/\n    Complete output (14 lines):\n    Traceback (most recent call last):\n      File \"/tmp/pip-install-9aj1_89m/salt_c268f994786e4625b26e772ffcf34b8f/salt/version.py\", line 15, in <module>\n        from platform import linux_distribution as _deprecated_linux_distribution\n    ImportError: cannot import name 'linux_distribution' from 'platform' (/usr/lib/python3.8/platform.py)\n    \n    During handling of the above exception, another exception occurred:\n    \n    Traceback (most recent call last):\n      File \"<string>\", line 1, in <module>\n      File \"/tmp/pip-install-9aj1_89m/salt_c268f994786e4625b26e772ffcf34b8f/setup.py\", line 126, in <module>\n        exec(compile(open(SALT_VERSION).read(), SALT_VERSION, 'exec'))\n      File \"/tmp/pip-install-9aj1_89m/salt_c268f994786e4625b26e772ffcf34b8f/salt/version.py\", line 22, in <module>\n        from distro import linux_distribution\n    ModuleNotFoundError: No module named 'distro'\n    ----------------------------------------\nERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.\nWARNING: You are using pip version 20.3.3; however, version 22.1.2 is available.\nYou should consider upgrading via the '/opt/stackstorm/virtualenvs/salt/bin/python -m pip install --upgrade pip' command.\n)\n",
        "exit_code": 1,
        "result": "None"
      }
    }
  ]
}
        
```
After ( installed via cli with branch pin )
```
root@bf6f4a5cd814:/opt/stackstorm# st2 pack install https://github.com/ITJamie/stackstorm-salt=upgrade_salt

	[ succeeded ] init_task
	[ succeeded ] download_pack
	[ succeeded ] make_a_prerun
	[ succeeded ] get_pack_dependencies
	[ succeeded ] check_dependency_and_conflict_list
	[ succeeded ] install_pack_requirements
	[ succeeded ] get_pack_warnings
	[ succeeded ] register_pack

+-------------+-----------------------+
| Property    | Value                 |
+-------------+-----------------------+
| ref         | salt                  |
| name        | salt                  |
| description | salt integration pack |
| version     | 1.0.1                 |
| author      | jcockhren             |
+-------------+-----------------------+
```

saltstack have removed python 2.X support since salt 3001 (jan 2021)
