### PR TITLE
Improve error reporting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 # Change Log
 
-## Unreleased; 3.0.0
+## Unreleased; 3.0.2
+
+### Add
+### Change
+### Removed
+
+## 3.0.1
 
 ### Add
 - Added TLS connection verification.
@@ -9,9 +15,15 @@
 ### Change
 - Formatted Python code with black.
 - Updated client authentication to work with Salt 3004 to 3006 (maybe higher)
+- Improved error reporting when HTTP errors are encountered.
+- Fail actions when HTTP return codes >=400
 
 ### Removed
 - Removed salt-pepper as a python dependency.
+
+## 3.0.0
+
+Retracted.
 
 ## 2.0.1
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ One can also use the generic "runner" action to execute arbitrary runners and ex
     st2 run salt.local module=pillar.items args=thing1,thing2
 ```
 
+Wheel command allows manipulation of keys on the master and requires careful crafting of the runner call.
+```bash
+    st2 run salt.runner module=wheel kwargs='{"client": "wheel", "fun": "key.finger", "match": "*"}'
+```
+
 ### Actions
 
 Saltstack runner/execution module function calls are represented as StackStorm actions. Considering Saltstack's [`archive` execution module](http://docs.saltstack.com/en/2014.7/ref/modules/all/salt.modules.archive.html#module-salt.modules.archive), every function would be exposed as an StackStorm action.

--- a/actions/client.py
+++ b/actions/client.py
@@ -5,9 +5,7 @@ from st2common.runners.base_action import Action
 
 class SaltClientAction(Action):
     def run(self, matches, module, args=[], kwargs={}):
-        """
-        CLI Examples:
-
+        """CLI Examples:
             st2 run salt.client matches='web*' module=test.ping
             st2 run salt.client module=pkg.install \
                     kwargs='{"pkgs":["git","httpd"]}'

--- a/actions/local.py
+++ b/actions/local.py
@@ -26,6 +26,7 @@ class SaltLocal(SaltAction):
             st2 run salt.local module=test.ping matches='web*'
             st2 run salt.local module=test.ping tgt_type=grain target='os:Ubuntu'
         """
+        self.verify_tls = self.config.get("verify_ssl", True)
 
         # ChatOps alias and newer St2 versions set default args=[] which
         # breaks test.ping & test.version
@@ -39,8 +40,11 @@ class SaltLocal(SaltAction):
         request = self.generate_request()
         request.prepare_body(json.dumps(self.data), None)
         resp = Session().send(request, verify=self.verify_tls)
-        try:
-            retval = resp.json()
-        except Exception as exc:
-            retval = (False, f"Failed to decode json! {str(exc)}")
-        return retval
+
+        if resp.ok:
+            try:
+                return resp.json()
+            except ValueError as exc:
+                return resp.text
+        else:
+            return (False, f"HTTP error {resp.status_code}\n{resp.text}")

--- a/actions/local.py
+++ b/actions/local.py
@@ -20,11 +20,9 @@ class SaltLocal(SaltAction):
     ]
 
     def run(self, module, target, tgt_type, args, **kwargs):
-        """
-        CLI Examples:
-
-            st2 run salt.local module=test.ping matches='web*'
-            st2 run salt.local module=test.ping tgt_type=grain target='os:Ubuntu'
+        """CLI Examples:
+        st2 run salt.local module=test.ping matches='web*'
+        st2 run salt.local module=test.ping tgt_type=grain target='os:Ubuntu'
         """
         self.verify_tls = self.config.get("verify_ssl", True)
 
@@ -44,7 +42,7 @@ class SaltLocal(SaltAction):
         if resp.ok:
             try:
                 return resp.json()
-            except ValueError as exc:
+            except ValueError:
                 return resp.text
         else:
             return (False, f"HTTP error {resp.status_code}\n{resp.text}")

--- a/actions/runner.py
+++ b/actions/runner.py
@@ -5,7 +5,6 @@ from lib.base import SaltAction
 
 
 class SaltRunner(SaltAction):
-
     __explicit__ = ["jobs", "manage", "pillar", "mine", "network"]
 
     def run(self, module, **kwargs):
@@ -15,15 +14,23 @@ class SaltRunner(SaltAction):
             st2 run salt.runner_jobs.active
             st2 run salt.runner_jobs.list_jobs
         """
+        self.verify_tls = self.config.get("verify_ssl", True)
+
         _cmd = module
 
         self.generate_package("runner", cmd=_cmd)
+
         if kwargs.get("kwargs", None) is not None:
             self.data.update(kwargs["kwargs"])
+
         request = self.generate_request()
-        self.logger.info("[salt] Request generated")
         request.prepare_body(json.dumps(self.data), None)
-        self.logger.info("[salt] Preparing to send")
         resp = Session().send(request, verify=self.verify_tls)
-        self.logger.debug("[salt] Response http code: %s", resp.status_code)
-        return resp.json()
+
+        if resp.ok:
+            try:
+                return resp.json()
+            except ValueError as exc:
+                return resp.text
+        else:
+            return (False, f"HTTP error {resp.status_code}\n{resp.text}")

--- a/actions/runner.py
+++ b/actions/runner.py
@@ -8,11 +8,9 @@ class SaltRunner(SaltAction):
     __explicit__ = ["jobs", "manage", "pillar", "mine", "network"]
 
     def run(self, module, **kwargs):
-        """
-        CLI Examples:
-
-            st2 run salt.runner_jobs.active
-            st2 run salt.runner_jobs.list_jobs
+        """CLI Examples:
+        st2 run salt.runner_jobs.active
+        st2 run salt.runner_jobs.list_jobs
         """
         self.verify_tls = self.config.get("verify_ssl", True)
 
@@ -30,7 +28,7 @@ class SaltRunner(SaltAction):
         if resp.ok:
             try:
                 return resp.json()
-            except ValueError as exc:
+            except ValueError:
                 return resp.text
         else:
             return (False, f"HTTP error {resp.status_code}\n{resp.text}")

--- a/actions/salt_bootstrap.py
+++ b/actions/salt_bootstrap.py
@@ -5,7 +5,6 @@ from st2common.runners.base_action import Action
 
 class SaltInstaller(Action):
     def run(self, name, provider, instance_id):
-        client = salt.cloud.CloudClient('/etc/salt/cloud')
-        ret = client.create(names=[name], provider=provider,
-                            instance_id=instance_id)
+        client = salt.cloud.CloudClient("/etc/salt/cloud")
+        ret = client.create(names=[name], provider=provider, instance_id=instance_id)
         return ret

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,7 +6,7 @@ keywords:
   - salt
   - cfg management
   - configuration management
-version: 3.0.0
+version: 3.0.1
 author : jcockhren
 email : jurnell@sophicware.com
 python_versions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-salt
+salt>=3006,<3007
+# dependency of salt 3006
+pyzmq==25.0.2
 requests

--- a/tests/test_action_local.py
+++ b/tests/test_action_local.py
@@ -34,7 +34,15 @@ class SaltLocalActionTestCase(testtools.TestCase, BaseActionTestCase):
         super(SaltLocalActionTestCase, self).setUp()
         self.m = self.useFixture(fixture.Fixture())
         self.action = self.get_action_instance(config=CONFIG_DATA)
-        self.m.register_uri("POST", "{}/run".format(CONFIG_DATA["api_url"]), json={})
+        # Mock authentication
+        self.m.register_uri(
+            "POST",
+            "{}/login".format(CONFIG_DATA["api_url"]),
+            json={},
+            headers={"X-Auth-Token": "mock-auth-ok-token"},
+        )
+        # Mock run API
+        self.m.register_uri("POST", "{}/".format(CONFIG_DATA["api_url"]), json={})
 
     def test_generic_action_no_args(self):
         self.action.run(**no_args)

--- a/tests/test_action_local.py
+++ b/tests/test_action_local.py
@@ -5,37 +5,26 @@ import requests_mock
 from requests_mock.contrib import fixture
 import testtools
 
-__all__ = [
-    'SaltLocalActionTestCase'
-]
+__all__ = ["SaltLocalActionTestCase"]
 
-no_args = {
-    'module': 'this.something',
-    'target': '*',
-    'tgt_type': 'glob',
-    'args': []
-}
+no_args = {"module": "this.something", "target": "*", "tgt_type": "glob", "args": []}
 
 one_arg = {
-    'module': 'this.something',
-    'target': '*',
-    'tgt_type': 'glob',
-    'args': ['os'],
+    "module": "this.something",
+    "target": "*",
+    "tgt_type": "glob",
+    "args": ["os"],
 }
 
 multiple_args = {
-    'module': 'this.something',
-    'target': '*',
-    'tgt_type': 'glob',
-    'args': ['this', 'that', 'home'],
+    "module": "this.something",
+    "target": "*",
+    "tgt_type": "glob",
+    "args": ["this", "that", "home"],
 }
 
-CONFIG_DATA = {
-    'api_url': 'https://example.com',
-    'username': 'this',
-    'password': 'that'
-}
-requests_mock.Mocker.TEST_PREFIX = 'test'
+CONFIG_DATA = {"api_url": "https://example.com", "username": "this", "password": "that"}
+requests_mock.Mocker.TEST_PREFIX = "test"
 
 
 class SaltLocalActionTestCase(testtools.TestCase, BaseActionTestCase):
@@ -45,20 +34,18 @@ class SaltLocalActionTestCase(testtools.TestCase, BaseActionTestCase):
         super(SaltLocalActionTestCase, self).setUp()
         self.m = self.useFixture(fixture.Fixture())
         self.action = self.get_action_instance(config=CONFIG_DATA)
-        self.m.register_uri('POST',
-                            "{}/run".format(CONFIG_DATA['api_url']),
-                            json={})
+        self.m.register_uri("POST", "{}/run".format(CONFIG_DATA["api_url"]), json={})
 
     def test_generic_action_no_args(self):
         self.action.run(**no_args)
-        self.assertNotIn('arg', self.action.data)
+        self.assertNotIn("arg", self.action.data)
 
     def test_generic_action_one_arg(self):
         self.action.run(**one_arg)
-        self.assertIn('arg', self.action.data)
-        self.assertIsInstance(self.action.data['arg'], list)
+        self.assertIn("arg", self.action.data)
+        self.assertIsInstance(self.action.data["arg"], list)
 
     def test_generic_action_multiple_args(self):
         self.action.run(**multiple_args)
-        self.assertIn('arg', self.action.data)
-        self.assertIsInstance(self.action.data['arg'], list)
+        self.assertIn("arg", self.action.data)
+        self.assertIsInstance(self.action.data["arg"], list)


### PR DESCRIPTION
The cause of API errors are not reported clearly up to the action and the action is marked as succeeded even with 500 Internal Error.  This change marks the action as failed and reports the Salt APIs HTTP response.

Added `wheel` example as it requires a slightly special invocation compared to other modules because the `client` keyword must used for the commands to work.

Pack pinned to 3006 and its dependencies.